### PR TITLE
Add support for script type module

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -160,7 +160,8 @@ var executableScriptsMimetypes = utils.createMap([
   'text/jscript',
   'application/javascript',
   'application/x-javascript',
-  'application/ecmascript'
+  'application/ecmascript',
+  'module'
 ]);
 
 function isScriptTypeAttribute(attrValue) {


### PR DESCRIPTION
This allows to minify the inline `<script type=module>` code. Without this they are ignored and not minified. Type `module` is a way how to use modern ES in browsers without transpilation.