### PR TITLE
Keep module type definition - closes #31

### DIFF
--- a/src/htmlminifier.js
+++ b/src/htmlminifier.js
@@ -164,9 +164,18 @@ var executableScriptsMimetypes = utils.createMap([
   'module'
 ]);
 
+var keepScriptsMimetypes = utils.createMap([
+  'module'
+]);
+
 function isScriptTypeAttribute(attrValue) {
   attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
   return attrValue === '' || executableScriptsMimetypes(attrValue);
+}
+
+function keepScriptTypeAttribute(attrValue) {
+  attrValue = trimWhitespace(attrValue.split(/;/, 2)[0]).toLowerCase();
+  return keepScriptsMimetypes(attrValue);
 }
 
 function isExecutableScript(tag, attrs) {
@@ -554,7 +563,7 @@ function normalizeAttr(attr, attrs, tag, options) {
   if (options.removeRedundantAttributes &&
     isAttributeRedundant(tag, attrName, attrValue, attrs) ||
     options.removeScriptTypeAttributes && tag === 'script' &&
-    attrName === 'type' && isScriptTypeAttribute(attrValue) ||
+    attrName === 'type' && isScriptTypeAttribute(attrValue) && !keepScriptTypeAttribute(attrValue) ||
     options.removeStyleLinkTypeAttributes && (tag === 'style' || tag === 'link') &&
     attrName === 'type' && isStyleLinkTypeAttribute(attrValue)) {
     return;

--- a/tests/minifier.js
+++ b/tests/minifier.js
@@ -1108,6 +1108,11 @@ QUnit.test('removing javascript type attributes', function(assert) {
   output = '<script>alert(1)</script>';
   assert.equal(minify(input, { removeScriptTypeAttributes: true }), output);
 
+  input = '<script type="modules">alert(1)</script>';
+  assert.equal(minify(input, { removeScriptTypeAttributes: false }), input);
+  output = '<script type="modules">alert(1)</script>';
+  assert.equal(minify(input, { removeScriptTypeAttributes: true }), output);
+
   input = '<script type="text/javascript">alert(1)</script>';
   assert.equal(minify(input, { removeScriptTypeAttributes: false }), input);
   output = '<script>alert(1)</script>';
@@ -1162,6 +1167,9 @@ QUnit.test('removing attribute quotes', function(assert) {
 
   input = '<input value="hello world">';
   assert.equal(minify(input, { removeAttributeQuotes: true }), '<input value="hello world">');
+
+  input = '<script type="module">alert(1);</script>';
+  assert.equal(minify(input, { removeAttributeQuotes: true }), '<script type=module>alert(1);</script>');
 
   input = '<a href="#" title="foo#bar">x</a>';
   assert.equal(minify(input, { removeAttributeQuotes: true }), '<a href=# title=foo#bar>x</a>');


### PR DESCRIPTION
For ECMAScript modules in browsers the type definition is required to
treat them as such.

Until now every script type was removed as browsers can still evaluate
the code in script tags, but this does not apply to ECMAScript modules
so we have to keep it in this case.